### PR TITLE
remove itunes:title

### DIFF
--- a/layouts/stories/stories.rss.xml
+++ b/layouts/stories/stories.rss.xml
@@ -32,7 +32,6 @@
     <language>{{ .Site.LanguageCode }}</language>
     <copyright>{{ .Site.Copyright }}</copyright>
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
-    <itunes:title>{{ $.Site.Title }}</itunes:title>
     <itunes:owner>
         <itunes:name>{{ .Site.Params.podcast.podcast_owner }}</itunes:name>
         <itunes:email>{{ .Site.Params.podcast.podcast_email }} </itunes:email>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "public"
-command = "hugo --gc --minify"
+command = "hugo --gc"
 
 [context.production.environment]
   HUGO_VERSION = "0.85.0"
@@ -11,4 +11,4 @@ command = "hugo --gc --minify"
   HUGO_VERSION = "0.85.0"
   
 [context.deploy-preview]
-  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
+  command = "hugo --gc -b $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Having this element seems to trip up xml validation, though it's listed as optional in Apple's guidelines.