### PR TITLE
Add initial devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+# Default ARGs are set in this file. To update them, update them in the devcontainer.json file
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+
+# Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 18, 16, 14
+ARG NODE_VERSION=16
+
+# VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
+ARG VARIANT=hugo
+
+# VERSION can be either 'latest' or a specific version number
+ARG VERSION=latest
+
+# Download Hugo
+RUN apt-get update && apt-get install -y ca-certificates openssl git curl golang && \
+    rm -rf /var/lib/apt/lists/* && \
+    case ${VERSION} in \
+    latest) \
+    export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
+    esac && \
+    echo ${VERSION} && \
+    case $(uname -m) in \
+    aarch64) \
+    export ARCH=ARM64 ;; \
+    *) \
+    export ARCH=64bit ;; \
+    esac && \
+    echo ${ARCH} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-${ARCH}.tar.gz && \
+    tar xf ${VERSION}.tar.gz && \
+    mv hugo /usr/bin/hugo
+
+# Hugo dev server port
+EXPOSE 1313

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+	"name": "Hugo (Community)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "hugo_extended",
+			// Update VERSION to pick a specific hugo version.
+			// Example versions: latest, 0.73.0, 0,71.1
+			// Rebuild the container if it already exists to update.
+			"VERSION": "latest",
+			// Update NODE_VERSION to pick the Node.js version: 12, 14
+			"NODE_VERSION": "14"
+		}
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"html.format.templating": true
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"bungcip.better-toml",
+				"davidanson.vscode-markdownlint"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1313
+	],
+
+        // runs hugo server to spin up site with live reload
+	"postCreateCommand": "hugo server",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	//"remoteUser": "node"
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,13 @@
+# Development
+
+This document describes how to get the opensourcestories.org site running locally.
+
+## Getting started
+
+This repository provides a devcontainer to make getting started with development easy. This supports running the development environment as a container locally with VSCode. This will spin up a hugo server and allow for local development with live code reloading without any dependencies on your local environment.
+
+**NOTE**: You can specify the version of Hugo to use in the `devcontainer.json` file. However it is recommended to use v0.102.0 or above to support commonly used development environments (arm64,amd64, etc.).
+
+### Using VSCode
+
+To get started with VSCode, you'll first need to ensure that you have the `Remote Development` extension pack installed. From there, all you'll need to do is launch `code` from the root of this repository. Once launched, VSCode will notice the existence of the .devcontainer directory and ask you to reopen the current folder to develop in a container. At this point, VSCode will relaunch and build the container if necessary. Once the container is built, your hugo server will be launched and you'll be able to access the current site at `http://localhost:1313`.


### PR DESCRIPTION
This adds an initial devcontainer via VSCode that spins up a Hugo server that supports live code reloading. It also creates an initial `DEVELOPMENT.md` to describe how to get started with it.

resolves #68 